### PR TITLE
카드 컴포넌트 제작

### DIFF
--- a/link-namu/src/components/atoms/Tag.jsx
+++ b/link-namu/src/components/atoms/Tag.jsx
@@ -1,0 +1,13 @@
+/**
+ * 카드 꼬리 영역에 사용할 태그 컴포넌트
+ * @param {string} name - 태그 명
+ */
+const Tag = ({ name }) => {
+    return (
+        <span className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 text-ellipsis overflow-hidden max-w-[80%]">
+            {name}
+        </span>
+    );
+}
+
+export default Tag;

--- a/link-namu/src/components/molecules/Card.jsx
+++ b/link-namu/src/components/molecules/Card.jsx
@@ -1,0 +1,40 @@
+import Tag from "../atoms/Tag";
+
+/**
+ * 카드 컴포넌트
+ * @param {string} imageUrl - 사진 URL
+ * @param {string} imageAlt - 사진 대체 텍스트
+ * @param {string} title - 북마크 제목
+ * @param {string} description - 북마크 설명
+ * @param {array<string>} tags - 태그 명 배열
+ */
+const Card = ({ imageUrl, imageAlt, title, description, tags }) => {
+  return (
+    <div className="w-72 h-80 border-2 bg-white shadow-md rounded-md">
+        {/* 이미지 영역 */}
+        <img src={imageUrl} alt={imageAlt} className="w-64 h-40 object-cover mx-auto my-1 rounded-sm" />
+
+        {/* 내용 영역 */}
+        <div className="px-4 py-4">
+            <div className="font-bold text-xl mb-2 text-ellipsis overflow-hidden">{title}</div>
+            <p className="text-gray-700 text-base text-ellipsis overflow-hidden">{description}</p>
+        </div>
+
+        {/* 꼬리 영역 */}
+        <div className="px-2 py-2">
+            {/* 태그 영역 */}
+            <span className="inline-block w-[80%]">
+                {tags.map((tag, index) => (
+                    <Tag key={index} name={tag} />
+                ))}
+            </span>
+            {/* 버튼 영역 */}
+            <span className="inline-block w-[20%]">
+                
+            </span>
+        </div>
+    </div>
+  );
+}
+
+export default Card;


### PR DESCRIPTION
태그 컴포넌트와 카드 컴포넌트를 제작했습니다.

1. 태그 컴포넌트
태그 명을 입력받아 태그를 생성합니다.
이름의 길이에 따라 크기가 가변적으로 늘어나지만, 부모 컴포넌트의 80% 길이를 넘으면,
이후의 이름은`...`으로 나오도록 했습니다.


2. 카드 컴포넌트
사진 url, 대체 텍스트, 제목, 설명, 태그 배열을 입력받아 카드를 생성합니다.
크기는 18 rem * 20 rem으로 고정되게 제작했습니다.
사진 부분, 본문 부분, 태그 부분, 버튼 부분으로 나누었습니다.

제목과, 설명이 한 줄을 넘는 경우 자르고 `...`으로 보이도록 했습니다.
태그가 카드의 크기를 넘어가는 경우, 테두리를 뚫고 나옵니다. (디자인 의논 예정)

https://www.notion.so/taeho1234/04148c51c36e4c67af4d528d9343a324



