### PR TITLE
기본 모달창 제작

### DIFF
--- a/link-namu/src/components/molecules/ModalBase.jsx
+++ b/link-namu/src/components/molecules/ModalBase.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+
+const modalSize = {
+  sm : '300px',
+  md : '600px',
+  lg : '900px',
+  xl : '1200px'
+}
+
+const ModalBase = ({ size, buttonName, titleName, prevName, nextName, children}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // 모달 열기 함수
+  const openModal = () => {
+    setIsOpen(true);
+  }
+
+  // 모달 닫기 함수
+  const closeModal = () => {
+    setIsOpen(false);
+  }
+
+  return (
+    <div>
+      {/* 테스트용 모달 열기 버튼 */}
+      <button onClick={openModal} className="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-700">
+        {buttonName}
+        버튼 이름
+      </button>
+      
+      {/* 모달 열린 상태일 때만 모달 창을 표시 */}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* 모달창 외부 */}
+          <div className="fixed inset-0 bg-black opacity-50" onClick={closeModal}></div>
+          <div className="z-50 w-11/12 mx-auto overflow-y-auto bg-white rounded shadow-lg md:max-w-md">
+            {/* 모달창 내부 */}
+            <div className="relative px-6 py-4 font-bold text-left">
+              제목
+              {titleName}
+            </div>
+            <div className="relative px-6 py-4 text-left">              
+              내부 컨텐츠
+              {children}
+            </div>
+            <div className="flex justify-between mt-4">
+              <button
+                className='m-4 text-gray-600 hover:text-gray-800'
+              >
+                &#xE000; 이전 {prevName}
+              </button>
+              <button
+                className='px-4 py-2 m-4 font-bold text-white bg-blue-500 rounded hover:bg-blue-700'
+              >
+                다음 {nextName} &#xE001;
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ModalBase;

--- a/link-namu/src/components/molecules/ModalBase.jsx
+++ b/link-namu/src/components/molecules/ModalBase.jsx
@@ -1,13 +1,22 @@
 import React, { useState } from 'react';
 
 const modalSize = {
-  sm : '300px',
-  md : '600px',
-  lg : '900px',
-  xl : '1200px'
+  sm : 'w-[15rem]',
+  md : 'w-[30rem]',
+  lg : 'w-[55rem]',
+  xl : 'w-[70rem]'
 }
 
-const ModalBase = ({ size, buttonName, titleName, prevName, nextName, children}) => {
+/**
+ * 기본 모달 창 컴포넌트
+ * @param {'sm', 'md', 'lg', 'xl'} size - 모달 창의 크기
+ * @param {string} buttonName - 모달 창을 여는 버튼의 이름
+ * @param {string} titleName - 모달 창의 제목
+ * @param {string} prevName - 모달 창 이전 버튼 이름
+ * @param {string} nextName - 모달 창 다음 버튼 이름
+ * @param {React.JSX.Element} children - 모달 창 내부 컴포넌트
+ */ 
+const ModalBase = ({ size = 'md', buttonName = '확인', titleName = '제목', prevName = '이전', nextName = '다음', children}) => {
   const [isOpen, setIsOpen] = useState(false);
 
   // 모달 열기 함수
@@ -25,34 +34,31 @@ const ModalBase = ({ size, buttonName, titleName, prevName, nextName, children})
       {/* 테스트용 모달 열기 버튼 */}
       <button onClick={openModal} className="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-700">
         {buttonName}
-        버튼 이름
       </button>
       
       {/* 모달 열린 상태일 때만 모달 창을 표시 */}
       {isOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           {/* 모달창 외부 */}
-          <div className="fixed inset-0 bg-black opacity-50" onClick={closeModal}></div>
-          <div className="z-50 w-11/12 mx-auto overflow-y-auto bg-white rounded shadow-lg md:max-w-md">
+          <div className="fixed inset-0 bg-black opacity-50 cursor-pointer" onClick={closeModal}></div>
+          <div className={`z-50 mx-auto overflow-y-auto bg-white rounded shadow-lg ${modalSize[size]}`}>
             {/* 모달창 내부 */}
-            <div className="relative px-6 py-4 font-bold text-left">
-              제목
+            <div className="relative px-6 py-4 text-xl font-bold text-left">
               {titleName}
             </div>
-            <div className="relative px-6 py-4 text-left">              
-              내부 컨텐츠
+            <div className="relative px-6 py-4 text-left">
               {children}
             </div>
             <div className="flex justify-between mt-4">
               <button
                 className='m-4 text-gray-600 hover:text-gray-800'
               >
-                &#xE000; 이전 {prevName}
+                &#xE000; {prevName}
               </button>
               <button
                 className='px-4 py-2 m-4 font-bold text-white bg-blue-500 rounded hover:bg-blue-700'
               >
-                다음 {nextName} &#xE001;
+                {nextName} &#xE001;
               </button>
             </div>
           </div>


### PR DESCRIPTION
다른 모달 창에 사용할 수 있도록 기본 모달 창 컴포넌트를 제작했습니다.
크기는 임의로 설정했습니다.
크기에 따른 설명은 노션에 추가하겠습니다.
모달 창을 여는 버튼에 기본 핸들러를 추가했고, 모달 창 외부 클릭 시 닫기를 적용했습니다.
나머지 부분에는 함수가 적용되지 않았습니다.


### 사용법
```jsx
<ModalBase size='md' titleName='북마크 추가하기' prevName='취소' nextName='다음'>
    <div>북마크 추가</div>
</ModalBase>
```

### 컴포넌트 속성
```jsx
/**
 * 기본 모달 창 컴포넌트
 * @param {'sm', 'md', 'lg', 'xl'} size - 모달 창의 크기
 * @param {string} buttonName - 모달 창을 여는 버튼의 이름
 * @param {string} titleName - 모달 창의 제목
 * @param {string} prevName - 모달 창 이전 버튼 이름
 * @param {string} nextName - 모달 창 다음 버튼 이름
 * @param {React.JSX.Element} children - 모달 창 내부 컴포넌트
 */ 
```

### 참고 사항
https://www.notion.so/taeho1234/6670af9991bd4d4c89bd76b41b46329d