### PR TITLE
메뉴바에 서버 데이터 적용

### DIFF
--- a/link-namu/src/components/molecules/Menubar.jsx
+++ b/link-namu/src/components/molecules/Menubar.jsx
@@ -1,36 +1,14 @@
+import { useState, useEffect } from "react";
 import WorkspaceItem from "../atoms/WorkspaceItem";
-
+import { getWorkspaceList } from "../../apis/workspace";
 const Menubar = () => {
-  const data = [
-    {
-      workspaceId: 1,
-      workspaceName: "나의 워크스페이스",
-      categoryList: [
-        {
-          categoryId: 1,
-          categoryName: "카테고리 1",
-        },
-        {
-          categoryId: 2,
-          categoryName: "카테고리 2",
-        },
-      ],
-    },
-    {
-      workspaceId: 2,
-      workspaceName: "나의 워크스페이스2",
-      categoryList: [
-        {
-          categoryId: 3,
-          categoryName: "카테고리 3",
-        },
-        {
-          categoryId: 4,
-          categoryName: "카테고리 4",
-        },
-      ],
-    },
-  ];
+  const [data, setData] = useState([]);
+  useEffect(() => {
+    getWorkspaceList().then((res) => {
+      console.log(res);
+      setData(res.data?.response);
+    });
+  }, []);
 
   return (
     <>

--- a/link-namu/src/pages/MainPage.jsx
+++ b/link-namu/src/pages/MainPage.jsx
@@ -1,4 +1,11 @@
+import cookies from "react-cookies";
+
 const MainPage = () => {
+  if (!cookies.load("accessToken")) {
+    window.location.href = "/signin";
+    return;
+  }
+
   return <div>main page</div>;
 };
 


### PR DESCRIPTION
#30 

- 워크스페이스 리스트 조회 API를 호출하여 데이터를 불러온 후 저장하여 메뉴바에 표시되도록 하였습니다.
- 로그인을 하지 않았을 때(쿠키에 accessToken 값이 없을 때) 로그인 페이지로 이동하도록 하였습니다.