### PR TITLE
Alert를 Toast 컴포넌트로 교체

### DIFF
--- a/link-namu/src/apis/api.js
+++ b/link-namu/src/apis/api.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import cookies from "react-cookies";
+import Toast from "../components/molecules/Toast";
 
 export const instance = axios.create({
   baseURL: process.env.REACT_APP_API_URL,
@@ -9,7 +10,7 @@ export const instance = axios.create({
   },
 });
 
-instance.interceptors.request.use((config) => {
+instance.interceptors.request.use(config => {
   const accessToken = cookies.load("accessToken");
   if (accessToken) {
     config.headers["Authorization"] = "Bearer " + accessToken;
@@ -19,15 +20,18 @@ instance.interceptors.request.use((config) => {
 
 // middleware
 instance.interceptors.response.use(
-  (response) => {
+  response => {
     return response;
   },
-  (error) => {
+  error => {
     console.log("error", error);
     const status = error?.response.status;
 
     if (status >= 500) {
-      alert("오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+      <Toast
+        message="오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+        type="error"
+      />;
     }
     return Promise.resolve(error.response);
   }

--- a/link-namu/src/components/molecules/Toast.jsx
+++ b/link-namu/src/components/molecules/Toast.jsx
@@ -1,24 +1,41 @@
-import { ToastContainer, toast } from 'react-toastify'
-import 'react-toastify/dist/ReactToastify.css'
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 /**
  * 메세지를 화면 중앙 하단에 출력하는 컴포넌트, 버튼과 메세지로 구성
  * @param {string} message - 토스트 메세지
  * @param {string} buttonName - 버튼 텍스트
  * @param {string} buttonStyle - tailwind CSS의 className 형식으로 작성
+ * @param {{error, success}} type - 토스트의 유형
  */
-const Toast = ({ message, buttonName, buttonStyle }) => {
-  const notify = () =>
-    toast.success(message, {
-      position: 'bottom-center',
-      autoClose: 5000,
-      hideProgressBar: false,
-      closeOnClick: true,
-      pauseOnHover: true,
-      draggable: true,
-      progress: undefined,
-      theme: 'light',
-    })
+const Toast = ({ message, buttonName, buttonStyle, type }) => {
+  var notify;
+
+  if (type === "success") {
+    notify = () =>
+      toast.success(message, {
+        position: "bottom-center",
+        autoClose: 5000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+        theme: "light",
+      });
+  } else if (type === "error") {
+    notify = () =>
+      toast.error(message, {
+        position: "bottom-center",
+        autoClose: 5000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+        theme: "light",
+      });
+  }
 
   return (
     <div>
@@ -38,7 +55,7 @@ const Toast = ({ message, buttonName, buttonStyle }) => {
         theme="light"
       />
     </div>
-  )
-}
+  );
+};
 
-export default Toast
+export default Toast;

--- a/link-namu/src/components/molecules/Toast.jsx
+++ b/link-namu/src/components/molecules/Toast.jsx
@@ -2,46 +2,13 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 /**
- * 메세지를 화면 중앙 하단에 출력하는 컴포넌트, 버튼과 메세지로 구성
+ * 메세지를 화면 중앙 하단에 출력하는 컴포넌트 메세지와 타입으로 구성
  * @param {string} message - 토스트 메세지
- * @param {string} buttonName - 버튼 텍스트
- * @param {string} buttonStyle - tailwind CSS의 className 형식으로 작성
  * @param {{error, success}} type - 토스트의 유형
  */
-const Toast = ({ message, buttonName, buttonStyle, type }) => {
-  var notify;
-
-  if (type === "success") {
-    notify = () =>
-      toast.success(message, {
-        position: "bottom-center",
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-        theme: "light",
-      });
-  } else if (type === "error") {
-    notify = () =>
-      toast.error(message, {
-        position: "bottom-center",
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-        theme: "light",
-      });
-  }
-
+const Toast = ({ message, type }) => {
   return (
     <div>
-      <button className={buttonStyle} onClick={notify}>
-        {buttonName}
-      </button>
       <ToastContainer
         position="bottom-center"
         autoClose={5000}
@@ -54,6 +21,28 @@ const Toast = ({ message, buttonName, buttonStyle, type }) => {
         pauseOnHover
         theme="light"
       />
+      {type === "success" &&
+        toast.success(message, {
+          position: "bottom-center",
+          autoClose: 5000,
+          hideProgressBar: false,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+          theme: "light",
+        })}
+      {type === "error" &&
+        toast.error(message, {
+          position: "bottom-center",
+          autoClose: 5000,
+          hideProgressBar: false,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+          theme: "light",
+        })}
     </div>
   );
 };

--- a/link-namu/src/index.js
+++ b/link-namu/src/index.js
@@ -8,8 +8,8 @@ import store from "./store";
 import { QueryClient, QueryClientProvider } from "react-query";
 import Toast from "./components/molecules/Toast";
 
-const queryErrorHandler = (error) => {
-  alert("queryErrorHandler"); //TODO: 토스트로 변경하기
+const queryErrorHandler = error => {
+  <Toast message="queryErrorHandler" type="error" />;
   console.log("queryErrorHandler", error);
 };
 


### PR DESCRIPTION
alert를 통해 오류를 출력하는 방식을 Toast 컴포넌트로 수정하였습니다.

Toast는 현재 메세지와 유형으로 구성되어 화면에 나타날 수 있도록 수정했습니다.
```
/**
 * 메세지를 화면 중앙 하단에 출력하는 컴포넌트 메세지와 타입으로 구성
 * @param {string} message - 토스트 메세지
 * @param {{error, success}} type - 토스트의 유형
 */
```

`src/api/api.js`와 `src/index.js`에서 alert를 동일한 메세지로 Toast 컴포넌트로 교체했습니다.

