### PR TITLE
액세스 토큰 저장 위치 변경과 새로고침 시 토큰 재발급 기능

### DIFF
--- a/link-namu/src/apis/api.js
+++ b/link-namu/src/apis/api.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import cookies from "react-cookies";
+import { getToken } from "../store";
 
 export const instance = axios.create({
   baseURL: process.env.REACT_APP_API_URL,
@@ -10,7 +10,7 @@ export const instance = axios.create({
 });
 
 instance.interceptors.request.use((config) => {
-  const accessToken = cookies.load("accessToken");
+  const accessToken = getToken();
   if (accessToken) {
     config.headers["Authorization"] = "Bearer " + accessToken;
   }

--- a/link-namu/src/apis/user.js
+++ b/link-namu/src/apis/user.js
@@ -33,6 +33,10 @@ export const logout = () => {
  */
 export const reissue = () => {
   const refreshToken = cookies.load("refreshToken");
+  if (!refreshToken) {
+    console.log("reissue: refresh token이 존재하지 않습니다.");
+    return;
+  }
   return instance.post("/api/auth/reissue", { refreshToken: refreshToken });
 };
 

--- a/link-namu/src/pages/MainPage.jsx
+++ b/link-namu/src/pages/MainPage.jsx
@@ -1,10 +1,35 @@
 import cookies from "react-cookies";
 import BookmarkGridTemplate from "../components/templates/BookmarkGridTemplate";
+import { useDispatch, useSelector } from "react-redux";
+import { reissue } from "../apis/user";
+import { setToken } from "../store/slices/userSlice";
 
 const MainPage = () => {
-  if (!cookies.load("accessToken")) {
-    window.location.href = "/signin";
-    return;
+  const dispatch = useDispatch();
+  const accessToken = useSelector((state) => {
+    return state.user.accessToken;
+  });
+
+  if (!accessToken) {
+    if (!cookies.load("refreshToken")) {
+      window.location.href = "/signin";
+      return;
+    }
+
+    reissue()
+      .then((res) => {
+        const accessToken = res.data?.response?.accessToken.split(" ")[1];
+        const refreshToken = res.data?.response?.refreshToken;
+
+        dispatch(
+          setToken({
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+          })
+        );
+        console.log("토큰이 재발급되었습니다.", accessToken);
+      })
+      .catch((err) => console.log(err));
   }
 
   return (

--- a/link-namu/src/store/index.js
+++ b/link-namu/src/store/index.js
@@ -9,4 +9,9 @@ const store = configureStore({
   },
 });
 
+const getToken = () => {
+  return store.getState().user.accessToken;
+};
+
 export default store;
+export { getToken };

--- a/link-namu/src/store/slices/userSlice.js
+++ b/link-namu/src/store/slices/userSlice.js
@@ -2,7 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import cookies from "react-cookies";
 
 const initialState = {
-  accessToken: cookies.load("accessToken"),
+  accessToken: null,
   refreshToken: cookies.load("refreshToken"),
 };
 
@@ -13,12 +13,12 @@ const userSlice = createSlice({
     setToken: (state, action) => {
       state.accessToken = action.payload.accessToken;
       state.refreshToken = action.payload.refreshToken;
-      cookies.save("accessToken", state.accessToken, {
-        path: "/",
-      });
-      cookies.save("refreshToken", state.refreshToken, {
-        path: "/",
-      });
+      if (state.refreshToken) {
+        cookies.save("refreshToken", state.refreshToken, {
+          path: "/",
+          // httpOnly: true,
+        });
+      }
     },
   },
 });


### PR DESCRIPTION
#44 

### 변경 사항
* 쿠키에 저장하던 access token을 store에 저장하도록 수정하였습니다.
* 쿠키에 refresh token 값이 없을 때, 로그인 화면으로 이동하도록 하였습니다.
* store의 access token 값이 없을 때(새로고침 시), 토큰을 재발급하도록 하였습니다.