### PR TITLE
임시보관함 및 카드 컴포넌트 수정

### DIFF
--- a/link-namu/src/components/atoms/DraggedCard.jsx
+++ b/link-namu/src/components/atoms/DraggedCard.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Draggable } from "react-beautiful-dnd";
+
+const DraggedCard = ({ id, title }) => {
+  return (
+    <Draggable key={id} draggableId={id} index={1}>
+      {provided => (
+        <div
+          className="w-56 h-24 p-4 m-1 bg-white border-2 rounded-md shadow-md"
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          <div className="overflow-hidden font-bold text-ellipsis">{title}</div>
+        </div>
+      )}
+    </Draggable>
+  );
+};
+
+export default React.memo(DraggedCard);

--- a/link-namu/src/components/molecules/Card.jsx
+++ b/link-namu/src/components/molecules/Card.jsx
@@ -16,6 +16,7 @@ const Card = ({
   bookmarkId = "",
   imageUrl = "",
   imageAlt = "",
+  url = "",
   title = "",
   description = "",
   tags = [],

--- a/link-namu/src/components/molecules/Card.jsx
+++ b/link-namu/src/components/molecules/Card.jsx
@@ -23,6 +23,10 @@ const Card = ({
 }) => {
   const [isDragging, setIsDragging] = useState(false);
 
+  const onClickHandler = () => {
+    window.location.href = url;
+  };
+
   return (
     <Draggable key={bookmarkId} draggableId={dragId} index={1}>
       {provided => (
@@ -33,6 +37,7 @@ const Card = ({
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
+          onClick={onClickHandler}
         >
           {/* 이미지 영역 */}
           <img

--- a/link-namu/src/components/molecules/TemporaryStorage.jsx
+++ b/link-namu/src/components/molecules/TemporaryStorage.jsx
@@ -33,7 +33,7 @@ const TemporaryStorage = ({ isOpen }) => {
           <div
             ref={provided.innerRef}
             {...provided.droppableProps}
-            className="h-[100%] flex flex-col items-center"
+            className="h-[100%] flex flex-col items-center overflow-y-scroll"
           >
             {cardList &&
               cardList.map(bookmark => {

--- a/link-namu/src/components/molecules/TemporaryStorage.jsx
+++ b/link-namu/src/components/molecules/TemporaryStorage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Droppable } from "react-beautiful-dnd";
-import Card from "./Card";
+import DraggedCard from "../atoms/DraggedCard";
 
 const TemporaryStorage = ({ isOpen }) => {
   const [isContents, setIsContents] = useState(false);
@@ -28,20 +28,19 @@ const TemporaryStorage = ({ isOpen }) => {
       <div>
         <h3 className="m-4 text-2xl font-bold text-center">임시보관함</h3>
       </div>
-      <Droppable droppableId="temp">
+      <Droppable droppableId="temp" direction="vertical">
         {(provided, snapshot) => (
           <div
             ref={provided.innerRef}
             {...provided.droppableProps}
-            className="h-96"
+            className="h-[100%] flex flex-col items-center"
           >
             {cardList &&
               cardList.map(bookmark => {
                 return (
-                  <Card
+                  <DraggedCard
                     key={bookmark.id}
-                    bookmarkId={bookmark.id}
-                    dragId={bookmark.id}
+                    id={bookmark.id}
                     title={bookmark.title}
                   />
                 );

--- a/link-namu/src/components/organisms/BookmarkGrid.jsx
+++ b/link-namu/src/components/organisms/BookmarkGrid.jsx
@@ -38,6 +38,11 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
         tempList = [{ id: id, title: title }];
         console.log(tempList);
       } else {
+        // 중복 확인
+        if (tempList.find(item => item.id === id) !== undefined) {
+          return;
+        }
+
         tempList = [...tempList, { id: id, title: title }];
         console.log(tempList);
       }

--- a/link-namu/src/components/organisms/BookmarkGrid.jsx
+++ b/link-namu/src/components/organisms/BookmarkGrid.jsx
@@ -102,6 +102,7 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
 
   return (
     <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart}>
+      <TemporaryStorage isOpen={isOpen} />
       <Droppable droppableId="grid" direction="horizontal">
         {(provided, snapshot) => (
           <div
@@ -134,7 +135,6 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
           </div>
         )}
       </Droppable>
-      <TemporaryStorage isOpen={isOpen} />
     </DragDropContext>
   );
 };

--- a/link-namu/src/components/organisms/BookmarkGrid.jsx
+++ b/link-namu/src/components/organisms/BookmarkGrid.jsx
@@ -120,6 +120,7 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
                     description={bookmark.description}
                     tags={bookmark.tags}
                     imageUrl={bookmark.imageUrl}
+                    url={bookmark.url}
                     dragId={
                       bookmark.bookmarkId +
                       bookmark.title +


### PR DESCRIPTION
### 한 일 
- 임시보관함에 카드가 중복으로 들어가는 현상 수정
- 카드 클릭 시 해당 url로 이동하는 기능 추가
- 투명 상태의 임시보관함이 카드보다 우선순위가 높은 현상 수정
- 임시보관함에 들어가는 카드를 드래그용 카드로 변경
- 임시보관함에 y축 스크롤 속성 추가