### PR TITLE
GNB 구현 및 메인 레이아웃 수정

### DIFF
--- a/link-namu/src/components/atoms/AddCategoryItem.jsx
+++ b/link-namu/src/components/atoms/AddCategoryItem.jsx
@@ -15,7 +15,9 @@ const AddCategoryItem = ({ workspaceId }) => {
           })
         }
       >
-        <span className="text-xs leading-4 text-left">+ 카테고리 추가</span>
+        <span className="text-xs leading-4 text-left whitespace-nowrap">
+          + 카테고리 추가
+        </span>
       </button>
     </div>
   );

--- a/link-namu/src/components/atoms/Breadcrumbs.jsx
+++ b/link-namu/src/components/atoms/Breadcrumbs.jsx
@@ -1,0 +1,18 @@
+const Breadcrumbs = ({ workspaceName = "", categoryName = "" }) => {
+  const arrow = <span className="font-semibold text-[#5c5e64]">{">"}</span>;
+  return (
+    <div className="inline-block p-2 m-3 border rounded-lg">
+      <div className="flex items-center text-sm justify-left gap-x-2 font-medium">
+        <span className={`text-[#5c5e64] text-[10px] leading-3 pl-3`}>
+          MAIN
+        </span>
+        {arrow}
+        <span>{workspaceName}</span>
+        {arrow}
+        <span>{categoryName}</span>
+      </div>
+    </div>
+  );
+};
+
+export default Breadcrumbs;

--- a/link-namu/src/components/atoms/CategoryContainer.jsx
+++ b/link-namu/src/components/atoms/CategoryContainer.jsx
@@ -7,7 +7,7 @@ import CategoryItem from "./CategoryItem";
  * @param {array} categories - 카테고리 리스트
  * @returns
  */
-const CategoryContainer = ({ workspaceId, categories }) => {
+const CategoryContainer = ({ workspaceId, workspaceName, categories }) => {
   return (
     <div className="ml-3">
       <div className="border-l-2 border-[#d9d9d9]">
@@ -16,6 +16,7 @@ const CategoryContainer = ({ workspaceId, categories }) => {
             <CategoryItem
               key={index}
               workspaceId={workspaceId}
+              workspaceName={workspaceName}
               categoryId={category.categoryId}
               categoryName={category.categoryName}
             />

--- a/link-namu/src/components/atoms/CategoryItem.jsx
+++ b/link-namu/src/components/atoms/CategoryItem.jsx
@@ -11,6 +11,7 @@ import CategoryContextMenu from "./CategoryContextMenu";
  */
 const CategoryItem = ({
   workspaceId,
+  workspaceName,
   categoryId,
   categoryName = "하위 카테고리",
 }) => {
@@ -58,6 +59,8 @@ const CategoryItem = ({
         onClick={() => {
           dispatch(
             setCurrCategory({
+              workspaceId: workspaceId,
+              workspaceName: workspaceName,
               categoryId: categoryId,
               categoryName: categoryName,
             })

--- a/link-namu/src/components/atoms/GNB.jsx
+++ b/link-namu/src/components/atoms/GNB.jsx
@@ -28,7 +28,7 @@ const GNB = ({ setState }) => {
                 <span className="text-base font-medium">🎄 LinkNamu</span>
               </button>
             </div>
-            <Searchbar />
+            {/* <Searchbar /> */}
             <LogoutButton />
           </div>
         </div>

--- a/link-namu/src/components/atoms/GNB.jsx
+++ b/link-namu/src/components/atoms/GNB.jsx
@@ -1,0 +1,43 @@
+import { useOpenModal } from "../../hooks/useOpenModal";
+import MODAL_TYPES from "../../constants/modal_types";
+import dehaze from "../../assets/dehaze.png";
+import Searchbar from "../atoms/Searchbar";
+import LogoutButton from "./LogoutButton";
+
+const GNB = ({ setState }) => {
+  return (
+    <>
+      <header className="m-0 p-0">
+        <div className="fixed left-0 right-[60px] top-0 z-11000 border-b bg-white">
+          <div className="w-full h-[56px] mx-auto px-4 flex items-center justify-between">
+            <div className="flex items-center">
+              <button
+                className="w-[46px] h-[46px] rounded-[60px] shadow-md bg-white hover:bg-[#d9d9d9] duration-300"
+                onClick={setState}
+              >
+                <div className="w-[30px] h-[30px] m-2">
+                  <img
+                    src={dehaze}
+                    alt="open menubar button"
+                    className="w-full h-full"
+                  />
+                </div>
+              </button>
+              <button
+                onClick={() => (window.location.href = "/")}
+                className="px-4 text-center"
+              >
+                <span className="text-base font-medium">🎄 LinkNamu</span>
+              </button>
+            </div>
+            {/* <Searchbar width="900px" /> */}
+            <LogoutButton />
+          </div>
+        </div>
+      </header>
+      <div className="space"></div>
+    </>
+  );
+};
+
+export default GNB;

--- a/link-namu/src/components/atoms/GNB.jsx
+++ b/link-namu/src/components/atoms/GNB.jsx
@@ -1,5 +1,3 @@
-import { useOpenModal } from "../../hooks/useOpenModal";
-import MODAL_TYPES from "../../constants/modal_types";
 import dehaze from "../../assets/dehaze.png";
 import Searchbar from "../atoms/Searchbar";
 import LogoutButton from "./LogoutButton";
@@ -30,7 +28,7 @@ const GNB = ({ setState }) => {
                 <span className="text-base font-medium">🎄 LinkNamu</span>
               </button>
             </div>
-            {/* <Searchbar width="900px" /> */}
+            <Searchbar />
             <LogoutButton />
           </div>
         </div>

--- a/link-namu/src/components/atoms/GlobalModal.jsx
+++ b/link-namu/src/components/atoms/GlobalModal.jsx
@@ -10,11 +10,11 @@ import NotionModal from "../organisms/NotionModal";
 import MODAL_TYPES from "../../constants/modal_types";
 import { useCloseModal } from "../../hooks/useCloseModal";
 import ShareLinkModal from "../organisms/ShareLinkModal";
-import Menubar from "../molecules/Menubar";
 import WorkspaceAddModal from "../organisms/WorkspaceAddModal";
 import WorkspaceDeleteModal from "../organisms/WorkspaceDeleteModal";
 import CategoryDeleteModal from "../organisms/CategoryDeleteModal";
 import GoogleDocsModal from "../organisms/GoogleDocsModal";
+import SaveShareLinkModal from "../organisms/SaveShareLinkModal";
 
 const MODAL_COMPONENTS = [
   {
@@ -46,8 +46,8 @@ const MODAL_COMPONENTS = [
     component: <ShareLinkModal />,
   },
   {
-    type: MODAL_TYPES.Menubar,
-    component: <Menubar />,
+    type: MODAL_TYPES.SaveShareLinkModal,
+    component: <SaveShareLinkModal />,
   },
   {
     type: MODAL_TYPES.WorkspaceDeleteModal,

--- a/link-namu/src/components/atoms/LogoutButton.jsx
+++ b/link-namu/src/components/atoms/LogoutButton.jsx
@@ -1,0 +1,21 @@
+import { logout } from "../../apis/user";
+import cookies from "react-cookies";
+
+const LogoutButton = () => {
+  const handleLogout = () => {
+    logout()
+      .then((res) => {
+        console.log(res);
+        cookies.remove("refreshToken", { path: "/" });
+        window.location.reload();
+      })
+      .catch((err) => console.log(err));
+  };
+  return (
+    <button className="" onClick={handleLogout}>
+      로그아웃
+    </button>
+  );
+};
+
+export default LogoutButton;

--- a/link-namu/src/components/atoms/Searchbar.jsx
+++ b/link-namu/src/components/atoms/Searchbar.jsx
@@ -1,23 +1,23 @@
 import { useState } from "react";
-import magnifier from "../../assets/Magnifier.png";
+import magnifier from "../../assets/magnifier.png";
 
 /**
  * 검색창 컴포넌트
  * @param {string} width - 컴포넌트 가로 길이
  * @returns
  */
-const Searchbar = ({ width = "700px" }) => {
+const Searchbar = ({ width = 600 }) => {
   const [isFocused, setIsFocus] = useState(false);
 
   return (
     <div
-      className={`w-[${width}] h-[50px] px-[20px] py-[10px] flex border border-black rounded-[50px] shadow-md`}
+      className={`w-[${width}px] h-[40px] px-[20px] py-[10px] flex border rounded-[50px] shadow-md`}
     >
       <div>
         <img
           src={magnifier}
           alt="magnifier icon"
-          className="w-[30px] h-[30px] "
+          className="w-[20px] h-[20px] "
         />
       </div>
       <input

--- a/link-namu/src/components/atoms/Sidebar.jsx
+++ b/link-namu/src/components/atoms/Sidebar.jsx
@@ -18,7 +18,6 @@ const Sidebar = () => {
 
   return (
     <>
-      <div className="w-[60px] h-screen"></div>
       <div
         className={`w-[60px] h-screen border-l bg-white fixed right-0 top-0 flex flex-col justify-end`}
       >

--- a/link-namu/src/components/atoms/WorkspaceItem.jsx
+++ b/link-namu/src/components/atoms/WorkspaceItem.jsx
@@ -71,6 +71,7 @@ const WorkspaceItem = ({
         {opened && categories && (
           <CategoryContainer
             workspaceId={workspaceId}
+            workspaceName={workspaceName}
             categories={categories}
           />
         )}

--- a/link-namu/src/components/molecules/Menubar.jsx
+++ b/link-namu/src/components/molecules/Menubar.jsx
@@ -1,29 +1,29 @@
 import WorkspaceItem from "../atoms/WorkspaceItem";
 import { useSelector } from "react-redux";
 import { selectWorkspaceList } from "../../store/slices/workspaceSlice";
-import { useOpenModal } from "../../hooks/useOpenModal";
 import { Scrollbars } from "react-custom-scrollbars-2";
+import { useEffect } from "react";
 
-import MODAL_TYPES from "../../constants/modal_types";
-import ModalCloseButton from "../atoms/ModalCloseButton";
-
-const Menubar = () => {
-  const openModal = useOpenModal();
+const Menubar = ({ isOpen }) => {
   const { workspaceList } = useSelector(selectWorkspaceList);
 
+  useEffect(() => {
+    console.log("isOpen", isOpen);
+  }, [isOpen]);
   return (
-    <>
+    <div>
       <div
-        className="w-[256px] h-screen fixed left-0 top-0 flex flex-col border border-[#d9d9d9] bg-white rounded-r-lg"
+        className={`${
+          isOpen ? "w-[256px]" : "w-0"
+        } duration-500 h-screen fixed left-0 top-0 flex flex-col border-r border-[#d9d9d9] bg-white`}
         onContextMenu={(e) => e.preventDefault()}
       >
-        <ModalCloseButton />
-        <div className="p-6 border-b border-[#d9d9d9] text-center">
-          <span className="text-base font-medium">🎄 LinkNamu</span>
-        </div>
-        <div className="flex-grow p-6">
+        <div className="h-[58px]"></div>
+        <div className={`flex-grow p-6`}>
           <span
-            className={"text-[#5c5e64] text-[10px] font-medium leading-3 pl-3"}
+            className={`${
+              !isOpen && "invisible"
+            } text-[#5c5e64] text-[10px] font-medium leading-3 pl-3`}
           >
             MAIN
           </span>
@@ -45,16 +45,14 @@ const Menubar = () => {
         </div>
         <div className="">
           <button
-            onClick={() =>
-              openModal({ modalType: MODAL_TYPES.WorkspaceAddModal })
-            }
-            className="block w-[190px] h-[36px] mx-auto my-5 border border-[#d9d9d9] rounded-md"
+            onClick={() => {}}
+            className="block w-[75%] h-[36px] mx-auto my-5 border border-[#d9d9d9] rounded-md overflow-hidden"
           >
-            워크스페이스 추가
+            <span className="whitespace-nowrap">워크스페이스 추가</span>
           </button>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/link-namu/src/components/molecules/TemporaryStorage.jsx
+++ b/link-namu/src/components/molecules/TemporaryStorage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Droppable } from "react-beautiful-dnd";
 import DraggedCard from "../atoms/DraggedCard";
+import Scrollbars from "react-custom-scrollbars-2";
 
 const TemporaryStorage = ({ isOpen }) => {
   const [isContents, setIsContents] = useState(false);
@@ -21,7 +22,7 @@ const TemporaryStorage = ({ isOpen }) => {
 
   return (
     <div
-      className={`fixed top-0 right-0 flex flex-col w-80 h-screen border-l bg-slate-200 ${
+      className={`fixed top-[56px] right-[60px] bottom-0 flex flex-col w-80 border-l bg-slate-200 ${
         isOpen || isContents ? `opacity-1 z-50` : `opacity-0 z-0`
       }`}
     >
@@ -30,23 +31,25 @@ const TemporaryStorage = ({ isOpen }) => {
       </div>
       <Droppable droppableId="temp" direction="vertical">
         {(provided, snapshot) => (
-          <div
-            ref={provided.innerRef}
-            {...provided.droppableProps}
-            className="h-[100%] flex flex-col items-center overflow-y-scroll"
-          >
-            {cardList &&
-              cardList.map(bookmark => {
-                return (
-                  <DraggedCard
-                    key={bookmark.id}
-                    id={bookmark.id}
-                    title={bookmark.title}
-                  />
-                );
-              })}
-            {provided.placeholder}
-          </div>
+          <Scrollbars>
+            <div
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              className="h-[100%] flex flex-col items-center"
+            >
+              {cardList &&
+                cardList.map((bookmark) => {
+                  return (
+                    <DraggedCard
+                      key={bookmark.id}
+                      id={bookmark.id}
+                      title={bookmark.title}
+                    />
+                  );
+                })}
+              {provided.placeholder}
+            </div>
+          </Scrollbars>
         )}
       </Droppable>
     </div>

--- a/link-namu/src/components/organisms/BookmarkGrid.jsx
+++ b/link-namu/src/components/organisms/BookmarkGrid.jsx
@@ -18,7 +18,7 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
   });
 
   // 드래그 종료
-  const onDragEnd = useCallback(result => {
+  const onDragEnd = useCallback((result) => {
     setIsOpen(false);
 
     if (result.destination === null) return;
@@ -39,7 +39,7 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
         console.log(tempList);
       } else {
         // 중복 확인
-        if (tempList.find(item => item.id === id) !== undefined) {
+        if (tempList.find((item) => item.id === id) !== undefined) {
           return;
         }
 
@@ -57,7 +57,7 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
     ) {
       const id = result.draggableId;
       let tempList = JSON.parse(window.localStorage.getItem("tempList"));
-      tempList = tempList.filter(bookmark => bookmark.id !== id);
+      tempList = tempList.filter((bookmark) => bookmark.id !== id);
 
       const payload = JSON.stringify({
         bookmarkList: [id],
@@ -70,7 +70,7 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
       mutate(
         { bookmarkIdList: [id], toCategoryId: categoryId },
         {
-          onError: error => {
+          onError: (error) => {
             console.log(error.response.data.error.message);
             printToast("이동에 실패했습니다.", "error");
           },
@@ -86,7 +86,7 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
   }, []);
 
   // 드래그 시작
-  const onDragStart = useCallback(result => {
+  const onDragStart = useCallback((result) => {
     setIsOpen(true);
   }, []);
 
@@ -117,7 +117,7 @@ const BookmarkGrid = ({ bookmarkList, categoryId }) => {
             {...provided.droppableProps}
           >
             {bookmarkList &&
-              bookmarkList.map(bookmark => {
+              bookmarkList.map((bookmark) => {
                 return (
                   <Card
                     bookmarkId={bookmark.bookmarkId}

--- a/link-namu/src/components/templates/BookmarkGridTemplate.jsx
+++ b/link-namu/src/components/templates/BookmarkGridTemplate.jsx
@@ -6,10 +6,10 @@ import { useSelector } from "react-redux";
 import BookmarkGrid from "../organisms/BookmarkGrid";
 
 const BookmarkGridTemplate = () => {
-  const currCategoryId = useSelector(state => {
+  const currCategoryId = useSelector((state) => {
     return state.bookmark.currCategoryId;
   });
-  const currCategoryName = useSelector(state => {
+  const currCategoryName = useSelector((state) => {
     return state.bookmark.currCategoryName;
   });
   const [categoryId, setCategoryId] = useState(currCategoryId);
@@ -22,7 +22,7 @@ const BookmarkGridTemplate = () => {
     ({ pageParam = 0 }) =>
       getCategoryList({ categoryId: currCategoryId, page: pageParam }),
     {
-      getNextPageParam: lastPage => {
+      getNextPageParam: (lastPage) => {
         if (!lastPage) return undefined;
         console.log("lastPage", lastPage);
         const currentPage = lastPage.data?.response?.pageInfo?.currentPage;
@@ -39,7 +39,7 @@ const BookmarkGridTemplate = () => {
     threshold: 0.5,
   };
 
-  const handleObserver = entities => {
+  const handleObserver = (entities) => {
     const target = entities[0];
     if (target.isIntersecting && hasNextPage) {
       fetchNextPage();
@@ -59,9 +59,9 @@ const BookmarkGridTemplate = () => {
   }, [bottomObserver, hasNextPage, fetchNextPage]);
 
   const bookmarkList = [];
-  data?.pages?.forEach(page => {
+  data?.pages?.forEach((page) => {
     if (page) {
-      page.data?.response?.bookmarkContents?.forEach(data => {
+      page.data?.response?.bookmarkContents?.forEach((data) => {
         bookmarkList.push(data);
       });
     }

--- a/link-namu/src/components/templates/BookmarkGridTemplate.jsx
+++ b/link-namu/src/components/templates/BookmarkGridTemplate.jsx
@@ -4,14 +4,14 @@ import { useInfiniteQuery } from "react-query";
 import { useSelector } from "react-redux";
 
 import BookmarkGrid from "../organisms/BookmarkGrid";
+import Breadcrumbs from "../atoms/Breadcrumbs";
 
 const BookmarkGridTemplate = () => {
-  const currCategoryId = useSelector((state) => {
-    return state.bookmark.currCategoryId;
-  });
-  const currCategoryName = useSelector((state) => {
-    return state.bookmark.currCategoryName;
-  });
+  const { currWorkspaceName, currCategoryId, currCategoryName } = useSelector(
+    (state) => {
+      return state.bookmark;
+    }
+  );
   const [categoryId, setCategoryId] = useState(currCategoryId);
   useEffect(() => {
     setCategoryId(currCategoryId);
@@ -69,7 +69,12 @@ const BookmarkGridTemplate = () => {
 
   return (
     <div>
-      <h1 className="text-[40px] text-center">{`현재 카테고리: ${currCategoryName} (ID: ${currCategoryId})`}</h1>
+      {currCategoryId && (
+        <Breadcrumbs
+          workspaceName={currWorkspaceName}
+          categoryName={currCategoryName}
+        />
+      )}
       {bookmarkList.length !== 0 && (
         <BookmarkGrid bookmarkList={bookmarkList} categoryId={currCategoryId} />
       )}

--- a/link-namu/src/constants/modal_types.js
+++ b/link-namu/src/constants/modal_types.js
@@ -6,10 +6,10 @@ const MODAL_TYPES = {
   CategoryAddModal: "CategoryAddModal",
   WorkspaceAddModal: "WorkspaceAddModal",
   ShareLinkModal: "ShareLinkModal",
-  Menubar: "Menubar",
   WorkspaceDeleteModal: "WorkspaceDeleteModal",
   CategoryDeleteModal: "CategoryDeleteModal",
   GoogleDocsModal: "GoogleDocsModal",
+  SaveShareLinkModal: "SaveShareLinkModal",
 };
 
 export default MODAL_TYPES;

--- a/link-namu/src/layouts/MainLayout.jsx
+++ b/link-namu/src/layouts/MainLayout.jsx
@@ -1,40 +1,33 @@
 import { Outlet } from "react-router-dom";
-import { useOpenModal } from "../hooks/useOpenModal";
 import { Scrollbars } from "react-custom-scrollbars-2";
 
 import Sidebar from "../components/atoms/Sidebar";
-import MODAL_TYPES from "../constants/modal_types";
-
-import dehaze from "../assets/dehaze.png";
+import GNB from "../components/atoms/GNB";
+import Menubar from "../components/molecules/Menubar";
+import { useState } from "react";
 
 const MainLayout = () => {
-  const openModal = useOpenModal();
+  const [isOpen, setIsOpen] = useState(true);
 
   return (
     <>
-      <div className="flex">
-        <div className="flex-1 h-screen">
+      <div className="w-full h-[56px]"></div>
+      <div className="fixed top-[56px] left-0 right-0 bottom-0 flex mr-[60px] overflow-y-hidden">
+        <div className={`${isOpen ? "w-[256px]" : "w-0"} duration-500`}>
+          <Menubar isOpen={isOpen} />
+        </div>
+        <div className="flex-1 h-[100%]">
           <Scrollbars thumbSize={100}>
             <Outlet />
           </Scrollbars>
         </div>
-        <Sidebar />
       </div>
-      {/* Menu */}
-      <div
-        className="w-[60px] h-[60px] m-[10px] fixed left-0 top-0 rounded-[60px] shadow-md cursor-pointer bg-white hover:bg-[#d9d9d9] duration-300"
-        onClick={() => {
-          openModal({ modalType: MODAL_TYPES.Menubar });
+      <GNB
+        setState={() => {
+          setIsOpen((prev) => !prev);
         }}
-      >
-        <div className="w-[40px] h-[40px] m-[10px]">
-          <img
-            src={dehaze}
-            alt="open menubar button"
-            className="w-full h-full"
-          />
-        </div>
-      </div>
+      />
+      <Sidebar />
     </>
   );
 };

--- a/link-namu/src/store/slices/bookmarkSlice.js
+++ b/link-namu/src/store/slices/bookmarkSlice.js
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
+  currWorkspaceId: null,
+  currWorkspaceName: "",
   currCategoryId: null,
   currCategoryName: "",
 };
@@ -10,6 +12,8 @@ const bookmarkSlice = createSlice({
   initialState,
   reducers: {
     setCurrCategory: (state, action) => {
+      state.currWorkspaceId = action.payload.workspaceId;
+      state.currWorkspaceName = action.payload.workspaceName;
       state.currCategoryId = action.payload.categoryId;
       state.currCategoryName = action.payload.categoryName;
     },


### PR DESCRIPTION
#92 

# 변경 사항
- GNB 컴포넌트를 추가하였습니다.
- global modal로 관리하던 메뉴바를 main layout에서 관리하도록 변경하였습니다.
- 메뉴바의 default 값을 open으로 바꿨습니다.
- main layout이 조절됨에 따라 임시보관함이 가려져서 position을 조정하였습니다.
- 현재 카테고리를 나타내기 위한 Breadcrumbs 컴포넌트를 추가하였습니다.
- 현재 워크스페이스 이름을 breadcrumbs에 표시하기 위하여, 카테고리 선택 시 워크스페이스 ID와 이름도 bookmark slice에 저장하도록 하였습니다.

![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/81626630/aacc4c89-d4ea-45bc-be81-b9af692d2c2b)
![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/81626630/de95fc3c-5202-4946-b66f-71e7a927b06c)
![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/81626630/541f4e61-e8c9-470a-9c5f-c5b7d113b0a3)
![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/81626630/22835ac1-6c13-4835-a793-a2edef075516)
