### PR TITLE
카카오 모달 수정 및 기능 추가

### DIFF
--- a/link-namu/src/components/atoms/BookmarkSelectItem.jsx
+++ b/link-namu/src/components/atoms/BookmarkSelectItem.jsx
@@ -7,7 +7,6 @@ const BookmarkSelectItem = ({
   id,
   checked = false,
   handleCheckedChange,
-  thumbnail = null,
   title,
   url = "",
   changeHandler = () => {},
@@ -35,15 +34,10 @@ const BookmarkSelectItem = ({
 
   return (
     <div
-      className={`grow flex flex-row gap-x-4 p-2 mb-1 border rounded-xl ${
+      className={`grow flex flex-row items-center gap-x-4 px-5 py-2 mr-3 mb-1 border rounded-xl ${
         checked ? "bg-[#ecf8fc]" : "bg-[#ffffff]"
       }`}
     >
-      <img
-        src={thumbnail}
-        alt="thumbnail"
-        className="w-[50px] h-[50px] border"
-      />
       <div className="grow">
         <input
           className="block w-full border"

--- a/link-namu/src/components/atoms/BookmarkSelectItem.jsx
+++ b/link-namu/src/components/atoms/BookmarkSelectItem.jsx
@@ -8,7 +8,7 @@ const BookmarkSelectItem = ({
   checked = false,
   handleCheckedChange,
   thumbnail = null,
-  title = "북마크 제목",
+  title,
   url = "",
   changeHandler = () => {},
 }) => {

--- a/link-namu/src/components/atoms/GlobalModal.jsx
+++ b/link-namu/src/components/atoms/GlobalModal.jsx
@@ -17,7 +17,6 @@ import SaveShareLinkModal from "../organisms/SaveShareLinkModal";
 import CategoryRenameModal from "../organisms/CategoryRenameModal";
 import WorkspaceRenameModal from "../organisms/WorkspaceRenameModal";
 import GoogleDocsModal from "../organisms/GoogleDocsModal";
-import SaveShareLinkModal from "../organisms/SaveShareLinkModal";
 
 const MODAL_COMPONENTS = [
   {

--- a/link-namu/src/components/atoms/ModalSubtitle.jsx
+++ b/link-namu/src/components/atoms/ModalSubtitle.jsx
@@ -2,7 +2,7 @@ const ModalSubtitle = ({ htmlFor, children }) => {
   return (
     <label
       htmlFor={htmlFor}
-      className="block px-6 py-2 text-xs text-[#2B4BF2] font-semibold"
+      className="block py-2 text-sm text-[rgba(0, 0, 0, 0.60)]"
     >
       {children}
     </label>

--- a/link-namu/src/components/atoms/ModalTitle.jsx
+++ b/link-namu/src/components/atoms/ModalTitle.jsx
@@ -1,7 +1,7 @@
 const ModalTitle = ({ children }) => {
   return (
     <div className="relative px-6 py-4 text-left">
-      <span className="text-xl font-bold">{children}</span>
+      <h2 className="text-xl text-center font-semibold">{children}</h2>
     </div>
   );
 };

--- a/link-namu/src/components/molecules/KakaoFileUpload.jsx
+++ b/link-namu/src/components/molecules/KakaoFileUpload.jsx
@@ -41,8 +41,7 @@ const KakaoFileUpload = ({ changeHandler }) => {
       if (!isFileSelected) throw new Error("파일을 선택해주세요.");
     } catch (err) {
       printToast(err.message, "error");
-      // throw new Error();
-      return;
+      throw new Error();
     }
     sendMeHandler();
   };

--- a/link-namu/src/components/molecules/KakaoFileUpload.jsx
+++ b/link-namu/src/components/molecules/KakaoFileUpload.jsx
@@ -7,6 +7,8 @@ import ModalBox from "../atoms/ModalBox";
 import file_icon from "../../assets/paper_icon.png";
 import upload_cloud from "../../assets/upload_cloud.png";
 import { printToast } from "../../utils/toast";
+import ModalTitle from "../atoms/ModalTitle";
+import ModalSubtitle from "../atoms/ModalSubtitle";
 
 const KakaoFileUpload = ({ changeHandler }) => {
   const dispatch = useDispatch();
@@ -137,10 +139,10 @@ const KakaoFileUpload = ({ changeHandler }) => {
     content: (
       <>
         <div className="mx-auto mt-5 text-center">
-          <h2 className="text-xl mb-4">카카오톡에서 가져오기</h2>
-          <span className="text-sm text-[rgba(0, 0, 0, 0.60)]">
+          <ModalTitle>카카오톡에서 가져오기</ModalTitle>
+          <ModalSubtitle>
             카카오톡에서 내보내기한 파일을 선택해주세요.
-          </span>
+          </ModalSubtitle>
         </div>
         <ModalBox>{fileSelectArea}</ModalBox>
       </>

--- a/link-namu/src/components/molecules/KakaoFileUpload.jsx
+++ b/link-namu/src/components/molecules/KakaoFileUpload.jsx
@@ -14,13 +14,30 @@ const KakaoFileUpload = ({ changeHandler }) => {
   const [selectedFile, setSelectedFile] = useState(null);
   const fileInput = useRef(null);
 
+  useEffect(() => {
+    console.log("선택된 파일", selectedFile);
+  }, [selectedFile]);
+
   // 파일 선택 핸들러
   const handleUpload = (e) => {
     fileInput.current.click();
   };
   const handleChange = (e) => {
-    console.log("selected file: ", e.target.files[0]);
     if (e.target.files[0]) setSelectedFile(e.target.files[0]);
+  };
+
+  const handleDragOver = (e) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      // 여기서 선택한 파일을 처리합니다.
+      const selectedFile = files[0];
+      setSelectedFile(selectedFile);
+    }
   };
 
   const removeFile = () => {
@@ -80,6 +97,8 @@ const KakaoFileUpload = ({ changeHandler }) => {
             ? "flex-row px-8 py-4 gap-x-8"
             : "flex-col p-14 gap-y-6 "
         }`}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
       >
         <img
           src={upload_cloud}

--- a/link-namu/src/components/molecules/KakaoFileUpload.jsx
+++ b/link-namu/src/components/molecules/KakaoFileUpload.jsx
@@ -38,7 +38,12 @@ const KakaoFileUpload = ({ changeHandler }) => {
     if (files.length > 0) {
       // 여기서 선택한 파일을 처리합니다.
       const selectedFile = files[0];
-      setSelectedFile(selectedFile);
+      const fileExtension = selectedFile.name.split(".").pop();
+      if (fileExtension === "txt" || fileExtension === "csv") {
+        setSelectedFile(selectedFile);
+      } else {
+        printToast("올바른 파일 형식이 아닙니다.", "error");
+      }
     }
   };
 

--- a/link-namu/src/components/molecules/KakaoSelectBookmark.jsx
+++ b/link-namu/src/components/molecules/KakaoSelectBookmark.jsx
@@ -126,6 +126,7 @@ const KakaoSelectBookmark = ({ data, getLinkList }) => {
                           handleCheckedChange={(e) => {
                             handleCheckedChange(e.target.checked, index);
                           }}
+                          title={item?.title}
                           url={item?.link}
                           changeHandler={(data) => {
                             changeData(index, data);

--- a/link-namu/src/components/molecules/KakaoSelectBookmark.jsx
+++ b/link-namu/src/components/molecules/KakaoSelectBookmark.jsx
@@ -5,6 +5,7 @@ import { createBookmark } from "../../apis/bookmark";
 
 import ModalBox from "../atoms/ModalBox";
 import { printToast } from "../../utils/toast";
+import { Scrollbars } from "react-custom-scrollbars-2";
 
 const KakaoSelectBookmark = ({ data, getLinkList }) => {
   const [isAllChecked, setIsAllChecked] = useState(false);
@@ -116,25 +117,27 @@ const KakaoSelectBookmark = ({ data, getLinkList }) => {
                     onClick={handleSelectAllClick}
                   />
                 </div>
-                <ul className="h-[450px] w-[800px] mx-auto p-2 overflow-y-scroll overflow-x-clip">
-                  {bookmarkList.map((item, index) => {
-                    return (
-                      <li key={index}>
-                        <BookmarkSelectItem
-                          id={index}
-                          checked={checkedIdList.includes(index)}
-                          handleCheckedChange={(e) => {
-                            handleCheckedChange(e.target.checked, index);
-                          }}
-                          title={item?.title}
-                          url={item?.link}
-                          changeHandler={(data) => {
-                            changeData(index, data);
-                          }}
-                        />
-                      </li>
-                    );
-                  })}
+                <ul className="h-[450px] w-[800px] mx-auto p-2">
+                  <Scrollbars>
+                    {bookmarkList.map((item, index) => {
+                      return (
+                        <li key={index}>
+                          <BookmarkSelectItem
+                            id={index}
+                            checked={checkedIdList.includes(index)}
+                            handleCheckedChange={(e) => {
+                              handleCheckedChange(e.target.checked, index);
+                            }}
+                            title={item?.title}
+                            url={item?.link}
+                            changeHandler={(data) => {
+                              changeData(index, data);
+                            }}
+                          />
+                        </li>
+                      );
+                    })}
+                  </Scrollbars>
                 </ul>
               </div>
             ))}

--- a/link-namu/src/components/molecules/KakaoSelectBookmark.jsx
+++ b/link-namu/src/components/molecules/KakaoSelectBookmark.jsx
@@ -57,21 +57,19 @@ const KakaoSelectBookmark = ({ data, getLinkList }) => {
   const addBookmarkList = () => {
     const selectedBookmarkList = [];
 
-    checkedIdList.forEach((id) => {
-      try {
+    try {
+      checkedIdList.forEach((id) => {
         if (bookmarkList[id].bookmarkName.length === 0) {
           throw new Error(id + " 북마크 제목은 공백일 수 없습니다.");
         }
         if (!bookmarkList[id].categoryId) {
           throw new Error(id + " 카테고리를 선택해주세요.");
         }
-      } catch (err) {
-        printToast(err.message, "error");
-        return;
-      }
-
-      selectedBookmarkList.push(bookmarkList[id]);
-    });
+        selectedBookmarkList.push(bookmarkList[id]);
+      });
+    } catch (err) {
+      printToast(err.message, "error");
+    }
 
     console.log("요청할 데이터 : ", selectedBookmarkList);
 

--- a/link-namu/src/components/molecules/KakaoSelectBookmark.jsx
+++ b/link-namu/src/components/molecules/KakaoSelectBookmark.jsx
@@ -6,6 +6,8 @@ import { createBookmark } from "../../apis/bookmark";
 import ModalBox from "../atoms/ModalBox";
 import { printToast } from "../../utils/toast";
 import { Scrollbars } from "react-custom-scrollbars-2";
+import ModalTitle from "../atoms/ModalTitle";
+import ModalSubtitle from "../atoms/ModalSubtitle";
 
 const KakaoSelectBookmark = ({ data, getLinkList }) => {
   const [isAllChecked, setIsAllChecked] = useState(false);
@@ -97,10 +99,8 @@ const KakaoSelectBookmark = ({ data, getLinkList }) => {
     content: (
       <div>
         <div className="mx-auto mt-5 text-center">
-          <h2 className="text-xl mb-4">발견된 링크</h2>
-          <span className="text-sm text-[rgba(0, 0, 0, 0.60)]">
-            추가할 링크를 선택해주세요.
-          </span>
+          <ModalTitle>발견된 링크</ModalTitle>
+          <ModalSubtitle>추가할 링크를 선택해주세요.</ModalSubtitle>
         </div>
         <ModalBox>
           {bookmarkList &&

--- a/link-namu/src/components/organisms/BookmarkAddModal.jsx
+++ b/link-namu/src/components/organisms/BookmarkAddModal.jsx
@@ -57,28 +57,6 @@ const BookmarkAddModal = () => {
       <ModalTitle>북마크 추가하기</ModalTitle>
       <ModalBox>
         <div>
-          <ModalSubtitle>워크스페이스 선택</ModalSubtitle>
-          <WorkspaceSeleceBox
-            value={workspaceId}
-            changeHandler={setWorkspaceId}
-          />
-        </div>
-        <div>
-          <ModalSubtitle>카테고리 선택</ModalSubtitle>
-          <CategorySelectBox
-            workspaceId={workspaceId}
-            value={categoryId}
-            changeHandler={setCategoryId}
-          />
-        </div>
-      </ModalBox>
-    </>
-  );
-  const page3 = (
-    <>
-      <ModalTitle>북마크 추가하기</ModalTitle>
-      <ModalBox>
-        <div>
           <ModalSubtitle>북마크 설명 (옵션)</ModalSubtitle>
           <ModalTextInput
             changeHandler={setBookmarkDescription}
@@ -146,9 +124,8 @@ const BookmarkAddModal = () => {
 
   const contentList = [];
   contentList.push({ content: page1 });
-  contentList.push({ content: page2 });
   contentList.push({
-    content: page3,
+    content: page2,
     title: "추가",
     buttonHandler: addBookmark,
   });


### PR DESCRIPTION
#46 

# 변경 사항
- 북마크 추가 모달에서 더 이상 사용하지 않는 페이지(워크스페이스/카테고리 선택 페이지) 제거
- 드래그 앤 드롭으로 로컬의 파일을 가져오는 기능 추가
- ModalTitle과 ModalSubtitle의 스타일 변경
- 카카오 모달의 제목과 소제목을 모달 컴포넌트를 사용하도록 변경
- 카카오 링크 추출 API의 응답에 추가된 title 정보를 표시하도록 변경
- 파일을 선택하지 않아도 다음 페이지로 넘어가는 에러 해결
- 카테고리를 선택하지 않은 아이템이 여러 개 일 때, 동시에 여러 토스트가 뜨는 문제 해결

![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/81626630/6984fe20-517c-43c1-ab28-521cb84fefbd)
![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/81626630/19e1fa37-9605-4ceb-aea4-a20ce70fc6de)
![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/81626630/1a766c4b-1488-4cb5-ab6d-4d273a3ea89e)
![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/81626630/a6bfa3b5-c85b-4615-ad6c-697a6ff9920b)
