### PR TITLE
드래그 카드에 한글의 길이가 범위를 넘는 경우, 카드 범위를 넘는 현상 수정

### DIFF
--- a/link-namu/src/components/atoms/DraggedCard.jsx
+++ b/link-namu/src/components/atoms/DraggedCard.jsx
@@ -11,7 +11,9 @@ const DraggedCard = ({ id, title }) => {
           {...provided.draggableProps}
           {...provided.dragHandleProps}
         >
-          <div className="overflow-hidden font-bold text-ellipsis">{title}</div>
+          <div className="overflow-hidden font-bold break-all text-ellipsis whitespace-nowrap">
+            {title}
+          </div>
         </div>
       )}
     </Draggable>


### PR DESCRIPTION
#127 

<br>

## 한 일
- 드래그 카드에 한글의 길이가 범위를 넘는 경우, 카드 범위를 넘는 현상 수정

![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/48244988/db532cec-50bc-4272-9e71-9714412e14de)


<br>