### PR TITLE
새로고침 시 현재 카테고리 유지되도록 변경

### DIFF
--- a/link-namu/src/App.jsx
+++ b/link-namu/src/App.jsx
@@ -29,12 +29,12 @@ const App = () => {
       reissue()
         .then((res) => {
           const accessToken = res.data?.response?.accessToken.split(" ")[1];
-          const refreshToken = res.data?.response?.refreshToken;
+          const newRefreshToken = res.data?.response?.refreshToken;
 
           dispatch(
             setToken({
               accessToken: accessToken,
-              refreshToken: refreshToken,
+              refreshToken: newRefreshToken,
             })
           );
           console.log("토큰이 재발급되었습니다.", accessToken);

--- a/link-namu/src/apis/api.js
+++ b/link-namu/src/apis/api.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getToken } from "../store";
+import { getAccessToken } from "../store";
 import { printToast } from "../utils/toast";
 
 export const instance = axios.create({
@@ -10,7 +10,7 @@ export const instance = axios.create({
 });
 
 instance.interceptors.request.use((config) => {
-  const accessToken = getToken();
+  const accessToken = getAccessToken();
   if (accessToken) {
     config.headers["Authorization"] = "Bearer " + accessToken;
   }

--- a/link-namu/src/components/atoms/CategoryItem.jsx
+++ b/link-namu/src/components/atoms/CategoryItem.jsx
@@ -72,14 +72,7 @@ const CategoryItem = ({
           categoryId === currCategoryId && "bg-[#f6f6f6]"
         } hover:bg-[#f6f6f6]`}
         onClick={() => {
-          dispatch(
-            setCurrCategory({
-              workspaceId: workspaceId,
-              workspaceName: workspaceName,
-              categoryId: categoryId,
-              categoryName: categoryName,
-            })
-          );
+          window.location.href = `${window.location.origin}?workspace=${workspaceId}&category=${categoryId}`;
         }}
         onContextMenu={openContextMenu}
       >

--- a/link-namu/src/store/index.js
+++ b/link-namu/src/store/index.js
@@ -13,9 +13,9 @@ const store = configureStore({
   },
 });
 
-const getToken = () => {
+const getAccessToken = () => {
   return store.getState().user.accessToken;
 };
 
 export default store;
-export { getToken };
+export { getAccessToken };


### PR DESCRIPTION
#113 

# 변경 사항
- 카테고리 아이템을 클릭하여 카테고리 선택 시, 현재 워크스페이스 id와 현재 카테고리 id를 쿼리 매개변수로 하여 동적 라우팅되도록 변경 (ex. https://localhost:3000/?workspace=4&category=8)