### PR TITLE
공유 카테고리 화면의 이미지 수정

### DIFF
--- a/link-namu/src/components/molecules/NonDraggableCard.jsx
+++ b/link-namu/src/components/molecules/NonDraggableCard.jsx
@@ -28,7 +28,7 @@ const NonDraggableCard = ({
       <img
         src={imageUrl}
         alt={imageAlt}
-        className="object-cover w-64 h-40 mx-auto my-1 rounded-sm"
+        className="object-contain w-64 h-40 mx-auto my-1 rounded-sm"
       />
 
       {/* 내용 영역 */}


### PR DESCRIPTION
공유 카테고리 화면에서 이미지를 비율에 맞게 컨테이너에 들어가도록 변경했습니다.
비율이 다를때, 여백이 생길 수 있습니다.