### PR TITLE
첫 렌더링에만 리스트를 호출하도록 변경

### DIFF
--- a/link-namu/src/pages/FirstAccessPage.jsx
+++ b/link-namu/src/pages/FirstAccessPage.jsx
@@ -12,7 +12,7 @@ const FirstAccessPage = () => {
         setBookmarkList(res.data.response);
       }
     });
-  }, [bookmarkList]);
+  }, []);
 
   return (
     <div className="flex flex-col items-center">


### PR DESCRIPTION
리스트를 무한 호출하는 버그가 있었습니다.
첫 렌더링에만 호출하도록 변경했습니다.