### PR TITLE
태그의 크기가 컴포넌트를 넘지 않도록 수정

### DIFF
--- a/link-namu/src/components/molecules/Card.jsx
+++ b/link-namu/src/components/molecules/Card.jsx
@@ -106,7 +106,7 @@ const Card = ({
             </div>
 
             {/* 꼬리 영역 */}
-            <div className="px-2 py-2">
+            <div className="px-2 py-2 overflow-hidden w-[90%]">
               {/* 태그 영역 */}
               <span className="flex w-full">
                 {tags.map((tag, index) => (

--- a/link-namu/src/components/molecules/NonDraggableCard.jsx
+++ b/link-namu/src/components/molecules/NonDraggableCard.jsx
@@ -42,7 +42,7 @@ const NonDraggableCard = ({
       </div>
 
       {/* 꼬리 영역 */}
-      <div className="px-2 py-2">
+      <div className="px-2 py-2 overflow-hidden w-[90%]">
         {/* 태그 영역 */}
         <span className="flex w-full">
           {tags.map((tag, index) => (


### PR DESCRIPTION
태그의 크기가 컴포넌트를 넘지 않도록 수정

![image](https://github.com/Step3-kakao-tech-campus/Team9_FE/assets/48244988/0d6efce2-ce1f-4601-bbc3-5eafa73a415e)

태그가 여러 개여도 크기를 넘어간다면, 보이지 않도록 만들었습니다.